### PR TITLE
feat(web): display candidate and assessment name dynamically on the Interview Recording Page

### DIFF
--- a/web/src/screens/InterviewRecordingPage.tsx
+++ b/web/src/screens/InterviewRecordingPage.tsx
@@ -5,7 +5,7 @@ import Webcam from 'react-webcam';
 import { axiosInstance } from '@/lib/axios';
 import { trackEvent } from '@/lib/rudderstack';
 import { InterviewRecordingPageTemplate } from '@/template';
-import { Quiz } from '@/types';
+import { Quiz, Interview } from '@/types';
 
 const InterviewRecordingPage = () => {
   const [videoFile, setVideoFile] = useState<File | null>(null);
@@ -14,6 +14,7 @@ const InterviewRecordingPage = () => {
   const [mediaRecorder, setMediaRecorder] = useState<MediaRecorder | null>(
     null
   );
+  const [interview, setInterview] = useState<Interview>();
   const [quizzes, setQuizes] = useState<Quiz[]>([]);
   const [quizIndex, setQuizIndex] = useState(0);
   // we want to have a separate progress bar count because on the last question
@@ -58,13 +59,14 @@ const InterviewRecordingPage = () => {
       );
       if (response.data.status === 'success') {
         // caseSensitiveAxiosInstance doesn't work
-        const interview = response.data.payload.interview;
-        interview.quizzes.map((quiz: any) => {
+        const theInterview = response.data.payload.interview;
+        theInterview.quizzes.forEach((quiz: any) => {
           quiz.questions = quiz.questions.map((question: any) => {
             return { ...question, questionNumber: question.question_number };
           });
         });
-        setQuizes(interview.quizzes);
+        setQuizes(theInterview.quizzes);
+        setInterview(theInterview);
       }
     } catch (error) {
       console.error(error);
@@ -166,6 +168,7 @@ const InterviewRecordingPage = () => {
     <InterviewRecordingPageTemplate
       isLoading={isLoading}
       quiz={quizzes[quizIndex]}
+      interview={interview}
       totalQuizCount={quizzes.length}
       progressbarCount={progressbarCount}
       isRecording={recording}

--- a/web/src/screens/InterviewRecordingPage.tsx
+++ b/web/src/screens/InterviewRecordingPage.tsx
@@ -59,14 +59,14 @@ const InterviewRecordingPage = () => {
       );
       if (response.data.status === 'success') {
         // caseSensitiveAxiosInstance doesn't work
-        const theInterview = response.data.payload.interview;
-        theInterview.quizzes.forEach((quiz: any) => {
+        const interviewPayload = response.data.payload.interview;
+        interviewPayload.quizzes.forEach((quiz: any) => {
           quiz.questions = quiz.questions.map((question: any) => {
             return { ...question, questionNumber: question.question_number };
           });
         });
-        setQuizes(theInterview.quizzes);
-        setInterview(theInterview);
+        setQuizes(interviewPayload.quizzes);
+        setInterview(interviewPayload);
       }
     } catch (error) {
       console.error(error);

--- a/web/src/template/InterviewRecordingPage/InterviewRecordingPage.stories.tsx
+++ b/web/src/template/InterviewRecordingPage/InterviewRecordingPage.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import Component from './InterviewRecordingPage';
 
-import { mockedSelectedQuiz } from '@/data';
+import { mockedSelectedQuiz, mockedInterview } from '@/data';
 
 const meta: Meta<typeof Component> = {
   title: 'Page',
@@ -17,6 +17,7 @@ export const InterviewRecordingPage: Story = {
   render: () => (
     <Component
       quiz={mockedSelectedQuiz}
+      interview={mockedInterview}
       isLoading={false}
       progressbarCount={2}
       totalQuizCount={4}

--- a/web/src/template/InterviewRecordingPage/InterviewRecordingPage.tsx
+++ b/web/src/template/InterviewRecordingPage/InterviewRecordingPage.tsx
@@ -119,9 +119,7 @@ const InterviewRecordingPageTemplate = ({
             </div>
             <div className="ml-auto flex items-center space-x-4 hidden sm:block">
               <p className="text-lg">
-                {interview?.assessment.name
-                  ? interview?.assessment.name
-                  : 'Assessment'}
+                {interview?.assessment.name ?? 'Assessment'}
               </p>
             </div>
           </div>

--- a/web/src/template/InterviewRecordingPage/InterviewRecordingPage.tsx
+++ b/web/src/template/InterviewRecordingPage/InterviewRecordingPage.tsx
@@ -2,7 +2,7 @@ import Webcam from 'react-webcam';
 
 import { Button, Icons, ProgressBar } from '@/components';
 import { env } from '@/config';
-import { Quiz } from '@/types';
+import { Quiz, Interview } from '@/types';
 
 const VIDEO_CONSTRAINTS: boolean | MediaTrackConstraints | undefined = {
   width: 1280,
@@ -24,6 +24,7 @@ interface InterviewRecordingPageTemplateProps {
   progressbarCount: number;
   totalQuizCount: number;
   quiz: Quiz;
+  interview: Interview | undefined;
   isLoading: boolean;
   isRecording: boolean;
   webcamRef?: React.RefObject<Webcam>;
@@ -37,6 +38,7 @@ const InterviewRecordingPageTemplate = ({
   progressbarCount,
   totalQuizCount,
   quiz,
+  interview,
   isLoading,
   isRecording,
   webcamRef,
@@ -107,10 +109,20 @@ const InterviewRecordingPageTemplate = ({
           </div>
           <div className="flex w-1/2 justify-around">
             <div className="ml-auto flex items-center space-x-4 hidden sm:block">
-              <p className="text-lg">Welcome, Takeshi Hashimoto</p>
+              <p className="text-lg">
+                Welcome
+                {interview?.candidate.name
+                  ? `, ${interview.candidate.name}`
+                  : ''}
+                !
+              </p>
             </div>
             <div className="ml-auto flex items-center space-x-4 hidden sm:block">
-              <p className="text-lg">Apple - SWE Test</p>
+              <p className="text-lg">
+                {interview?.assessment.name
+                  ? interview?.assessment.name
+                  : 'Assessment'}
+              </p>
             </div>
           </div>
         </div>
@@ -118,7 +130,8 @@ const InterviewRecordingPageTemplate = ({
         {/* Time and Question count */}
         <div className="flex items-center justify-center px-20 pt-4 border-matcha-700 pb-4">
           <div className="w-1/2">
-            <p className="text-2xl font-bold">3:38</p>
+            {/* TODO: implement a functional timer later */}
+            {/* <p className="text-2xl font-bold">3:38</p> */}
           </div>
           <div className="flex justify-end">
             <ProgressBar

--- a/web/src/template/InterviewRecordingPage/InterviewRecordingPage.tsx
+++ b/web/src/template/InterviewRecordingPage/InterviewRecordingPage.tsx
@@ -24,7 +24,7 @@ interface InterviewRecordingPageTemplateProps {
   progressbarCount: number;
   totalQuizCount: number;
   quiz: Quiz;
-  interview: Interview | undefined;
+  interview?: Interview;
   isLoading: boolean;
   isRecording: boolean;
   webcamRef?: React.RefObject<Webcam>;


### PR DESCRIPTION
1. Candidate and Assessment name are loaded from the interview data
  a. Sensible defaults are provided while waiting:
    - Default candidate name is `Welcome!`. Loaded name is `Welcome, Thomas!`. Exclamation mark can be removed if wanted.
    - Default assessment name is `Assessment`. Loaded name is `My Assessment Name`.
2. Commented out the timer code.

Fixes #1012