### PR TITLE
feat(web): Change layout to make it clear the user need to select at least one quiz

### DIFF
--- a/web/src/components/Card/QuestionCard/QuestionCard.tsx
+++ b/web/src/components/Card/QuestionCard/QuestionCard.tsx
@@ -11,16 +11,12 @@ import {
 import { Quiz } from '@/types';
 
 interface QuestionCardProps {
-  quiz: Quiz
+  quiz: Quiz;
   selected: boolean;
   onClick?: () => void;
 }
 
-const QuestionCard = ({
-  quiz,
-  selected,
-  onClick,
-}: QuestionCardProps) => {
+const QuestionCard = ({ quiz, selected, onClick }: QuestionCardProps) => {
   return (
     <Card
       className={`cursor-pointer hover:shadow-md rounded-lg shadow  ${
@@ -31,8 +27,11 @@ const QuestionCard = ({
       <CardHeader className="w-full space-y-0 pt-3 pb-0">
         <div className="space-y-1 w-full">
           <div className="w-full flex  items-center justify-between">
-            <CardTitle className="ml-3 text-sm text-muted-foreground">
+            {/* <CardTitle className="ml-3 text-sm text-muted-foreground">
               Quiz
+            </CardTitle> */}
+            <CardTitle className="text-sm text-muted-foreground">
+              {quiz.subtopic}
             </CardTitle>
             <div
               className=""

--- a/web/src/components/Card/QuestionCard/QuestionCard.tsx
+++ b/web/src/components/Card/QuestionCard/QuestionCard.tsx
@@ -19,10 +19,14 @@ interface QuestionCardProps {
 const QuestionCard = ({ quiz, selected, onClick }: QuestionCardProps) => {
   return (
     <Card
-      className={`cursor-pointer hover:shadow-md rounded-lg shadow  ${
+      // className={`cursor-pointer hover:shadow-md rounded-lg shadow  ${
+      //   selected ? 'border-matcha-400 bg-matcha-30' : 'bg-white'
+      // }`}
+      className={`cursor-pointer hover:border-matcha-400 rounded-lg shadow  ${
         selected ? 'border-matcha-400 bg-matcha-30' : 'bg-white'
       }`}
       onClick={onClick}
+      title="Add to Assessment"
     >
       <CardHeader className="w-full space-y-0 pt-3 pb-0">
         <div className="space-y-1 w-full">

--- a/web/src/template/CreateAssessmentPage/CreateAssessmentPage.tsx
+++ b/web/src/template/CreateAssessmentPage/CreateAssessmentPage.tsx
@@ -231,6 +231,7 @@ const CreateAssessmentPageTemplate = ({
             ) : null}
             {quizzes.map(quiz => (
               <QuestionCard
+                key={quiz.id}
                 quiz={quiz}
                 selected={selectedQuizzes.some(q => q.id === quiz.id)}
                 onClick={() => {

--- a/web/src/template/CreateAssessmentPage/CreateAssessmentPage.tsx
+++ b/web/src/template/CreateAssessmentPage/CreateAssessmentPage.tsx
@@ -162,25 +162,29 @@ const CreateAssessmentPageTemplate = ({
               value={description}
             />
           </div>
-          <div className="mt-4 w-full flex items-center justify-end">
+          {/* <div className="mt-4 w-full flex items-center justify-end">
             <Link to="/assessments">
               <p className="font-bold text-black mr-6 cursor-pointer">Cancel</p>
             </Link>
             <Button
               onClick={onSubmit}
-              disabled={isLoading}
+              disabled={isLoading || selectedQuizzes.length == 0}
               className="font-bold bg-matcha-400 text-white hover:bg-matcha-500 hover:text-white py-4 px-3"
             >
               Create Assessment
             </Button>
-          </div>
+          </div> */}
         </div>
       </div>
-      <div className="w-full px-4 md:px-12 xl:pl-8 space-y-4 pt-16 pr-1">
+      <div className="w-full px-4 md:px-12 xl:pl-8 space-y-4 pt-16 pr-1 flex flex-col">
         <div className="">
           <h3 className="text-2xl font-bold">
             You have selected {selectedQuizzes.length} quizzes
           </h3>
+          <p>
+            Quizzes provide contexts to your questions. An assessment can
+            contain multiple quizzes and a quiz can contain multiple questions.
+          </p>
         </div>
         <div className="flex w-full space-x-3 my-2">
           <div className="w-full">
@@ -218,26 +222,41 @@ const CreateAssessmentPageTemplate = ({
           </Select>
           <Button onClick={handleGenerateQuiz}>Generate with AI</Button>
         </div>
-        <div className="space-y-4 overflow-y-auto max-h-[490px]">
-          {isLoadingQuestionGeneration ? <LoadingCard /> : null}
-          {quizzes.length === 0 ? (
-            <p className="text-lg font-bold text-black">No quizzes found</p>
-          ) : null}
-          {quizzes.map(quiz => (
-            <QuestionCard
-              quiz={quiz}
-              selected={selectedQuizzes.some(q => q.id === quiz.id)}
-              onClick={() => {
-                if (selectedQuizzes.some(q => q.id === quiz.id)) {
-                  setSelectedQuizzes(
-                    selectedQuizzes.filter(q => q.id !== quiz.id)
-                  );
-                } else {
-                  setSelectedQuizzes([...selectedQuizzes, quiz]);
-                }
-              }}
-            />
-          ))}
+        <div className="h-full relative">
+          {/* <div className="space-y-4 overflow-y-auto max-h-[490px] absolute"> */}
+          <div className="space-y-4 overflow-y-auto h-full absolute">
+            {isLoadingQuestionGeneration ? <LoadingCard /> : null}
+            {quizzes.length === 0 ? (
+              <p className="text-lg font-bold text-black">No quizzes found</p>
+            ) : null}
+            {quizzes.map(quiz => (
+              <QuestionCard
+                quiz={quiz}
+                selected={selectedQuizzes.some(q => q.id === quiz.id)}
+                onClick={() => {
+                  if (selectedQuizzes.some(q => q.id === quiz.id)) {
+                    setSelectedQuizzes(
+                      selectedQuizzes.filter(q => q.id !== quiz.id)
+                    );
+                  } else {
+                    setSelectedQuizzes([...selectedQuizzes, quiz]);
+                  }
+                }}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="mt-4 w-full flex items-center justify-end">
+          <Link to="/assessments">
+            <p className="font-bold text-black mr-6 cursor-pointer">Cancel</p>
+          </Link>
+          <Button
+            onClick={onSubmit}
+            disabled={isLoading || selectedQuizzes.length == 0}
+            className="font-bold bg-matcha-400 text-white hover:bg-matcha-500 hover:text-white py-4 px-3"
+          >
+            Create Assessment
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION

**What I added**
- Move the Create Assessment button to the right of the screen
  - The current design make it seem like the user is done when the left side is filled out. 
  - By moving it to the right, we implicitly tell the user that the Quiz side is part of the page as well -> they'll need to select a quiz
- Disable the Create Assessment button until at least a quiz is selected
  - I decided against the tooltip since the flow speaks for itself.
  - For example, GitHub's [create issue page](https://github.com/matchya/matchya/issues/new) doesn't have a tooltip on the  submit button when there's no data.
- Changed the hard coded "Quiz" card title to `quiz.subtopic`. 

![image](https://github.com/matchya/matchya/assets/43018778/3404942f-91e4-44b7-bcaf-ea80ca877cc8)

- Added a description on what the quiz is about.
  - It explains why you need a quiz and why it's different than an assessment
  - Might need to tell the user somehow that they need to select at least a quiz somehow
    - My attempt at this is to make the onhover effect of the border more clear
    - I also thought of a tooltip like "Add to Assessment" but I'm not sure if it's needed. A temporary "title" is added in the picture below to mimic the behaviour. 
    - Let me know if you think it's worth it to have a proper tooltip. For style, I'm thinking matcha green with rounded-border
 

![image](https://github.com/matchya/matchya/assets/43018778/08bfcae8-d6e5-4d98-9c74-bf1829dac581)

Black part is my imaginary cursor
![image](https://github.com/matchya/matchya/assets/43018778/913850e1-eb89-4fc8-a5b8-1f6827fdc7e2)


**What I need your help with**
- Review my suggestions above -> let me know if anything needed changing 
  - Everything is up for review. Just let me know:
    - If you want to change the description for the quiz
    - If you like the layout change
    - Your thoughts on the card hover effect and title change
- Main section height increase:
  - With the button and the description, the right hand side look a bit tight. I'd like to suggest increasing the height of the main section. There seems to be a lot of space (see below) that we can use.

![image](https://github.com/matchya/matchya/assets/43018778/1223ac95-6088-42d8-84dd-344e747e3794)

- UX/UI suggestion: create a section that shows the user the quizzes that they have selected
  - Use case:
    - I scroll down to the bottom and selected a quiz
    - Scroll to the middle, pick a quiz
    - Scroll to the top, pick another quiz
    - Go for a break
    - Come back, don't remember the quizzes that I've picked -> need to scroll through everything again to see my quizzes
  - Suggestions
    - Add another section underneath the description that lists out the name of the added quiz:
      - The names can be a chip like the Python and Easy chips.
      - Pro: simple and does the job
      - Cons: take up a lot of space
 
![image](https://github.com/matchya/matchya/assets/43018778/dbdd34dd-ed65-4543-b6da-d2e5ee636246)

  - Replace the description section with this "Quiz Added" section
    - Move the description into a tooltip and change the "quiz" text of "You have selected x quiz" into a hoverable trigger
    - Could have a question mark next to it.
- This is a nice-to-have considering that we are near the launch date. Don't worry too hard about it, just tossing it out there.
 
This closes #1052 